### PR TITLE
[WIP] MuseScore 4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ A MuseScore plugin. Drop-in replacement for its layout engine that fixes all sys
 
 ![Demo of CastOff in action](https://raw.githubusercontent.com/mrjacobbloom/castoff/master/demo.gif)
 
+After you've finished note entry and are ready to think about layout, enable this plugin. It'll automagically (do its best to) fix all systems to 2, 4, or 8 measures. What's more, it stays on after that, so you can start to add your own system or page breaks, and it'll continue to adjust the rest of the score as you go! Basically, from that point on, you can treat it like a drop-in replacement for the built-in layout system.
+
 Right now there's only a MuseScore 3 version, as MuseScore 4's plugin API hasn't stabilized yet as of this writing and I expect this plugin to not be compatible.
 
 See comment at top of plugin for technical rant.

--- a/castoff.qml
+++ b/castoff.qml
@@ -1,5 +1,5 @@
 /**
- * CastOff - by Jacob Bloom - Updated Feb. 2023 - MuseScore 3 version
+ * CastOff - by Jacob Bloom - Updated Mar. 2023 - MuseScore 3-4 version
  *
  * How to use: After you've finished note entry and are ready to think about layout, enable this plugin. It'll
  * automagically (do its best to) fix all systems to 2, 4, or 8 measures. What's more, it stays on after that,
@@ -35,13 +35,24 @@ import QtQuick.Controls 2.2
 import MuseScore 3.0
 
 MuseScore {
-      menuPath: 'Plugins.CastOff';
+      id: castoff;
       description: 'A drop-in replacement for MuseScore\'s layout engine that fixes all systems to 2, 4, or 8 measures.';
-      version: '1.0';
+      version: '2.0';
 
       pluginType: 'dock';
-      dockArea:   'left';
       anchors.fill: parent;
+
+      Component.onCompleted: {
+            if (mscoreMajorVersion >= 4) {
+                  castoff.title = 'CastOff';
+                  castoff.categoryCode = 'composing-arranging-tools';
+                  castoff.pluginType = 'dialog';
+                  castoff.thumbnailName = 'logo.png';
+            } else {
+                  castoff.menuPath = 'Plugins.CastOff';
+                  castoff.dockArea = 'left';
+            }
+      }
 
       /**
        * List of casting-off options available to the user, and their human-friendly names
@@ -279,9 +290,9 @@ MuseScore {
        * @returns {void}
        */
        function overrideButtonStyles(self, borderColor) {
-            this.background.border.color = borderColor || '#bbb';
-            this.background.border.width = 1;
-            this.contentItem.wrapMode = Text.WordWrap;
+            self.background.border.color = borderColor || '#bbb';
+            self.background.border.width = 1;
+            self.contentItem.wrapMode = Text.WordWrap;
        }
 
       /**
@@ -457,6 +468,7 @@ MuseScore {
                               removeElement(element);
                         }
                   }
+                  console.log('MEASURE', JSON.stringify(measure));
             } while (measure = measure.nextMeasure);
       }
       
@@ -529,7 +541,7 @@ MuseScore {
        */
       function doLayout () {
             var cursor = curScore.newCursor();
-            cursor.rewindToTick(startLayoutTick);
+            cursor.rewindToTick(startLayoutTick || 0);
             if (!cursor.measure) return;
             rewindToFirstMeasureInSystem(cursor)
             


### PR DESCRIPTION
I added the boilerplate for MS4.

## Roadblocks
### Automatic view-mode switching
CastOff quickly switches to horizontally-continuous mode to collect the minimum widths of measures. This can no longer be done automatically in MuseScore 4 because it looks like support was dropped for `cmd('viewmode')`.

Registering commands generally looks like this [[1]](https://github.com/musescore/MuseScore/blob/f983aa0298f06cdd2e26187e70b849a9d70dd1bc/src/notation/internal/notationactioncontroller.cpp#L82) [[2]](https://github.com/musescore/MuseScore/blob/4.0.2/src/project/internal/projectuiactions.cpp#L30) but there's no equivalent registered command in [notationviewstate.cpp](https://github.com/musescore/MuseScore/blob/591ef84903769a858d1667059918ccb7cb551721/src/notation/internal/notationviewstate.cpp)

## Todo

- [ ] Finish getting it running
- [ ] Add MS4 installation instructions to readme (basically that it has to be in a folder)
- [ ] Consider adding a logo
- [ ] Update [wiki entry on musescore.org](https://musescore.org/en/project/castoff-fix-all-systems-2-4-or-8-measures-casting)